### PR TITLE
Fix actions

### DIFF
--- a/studio/schemas/companyInfo.js
+++ b/studio/schemas/companyInfo.js
@@ -5,6 +5,7 @@ export default {
   title: 'Company Info',
   type: 'document',
   liveEdit: false,
+   __experimental_actions: ['update', 'publish', /*'create', 'delete'*/],
   icon: MdBusiness,
   fields: [
     {

--- a/studio/schemas/companyInfo.js
+++ b/studio/schemas/companyInfo.js
@@ -5,7 +5,7 @@ export default {
   title: 'Company Info',
   type: 'document',
   liveEdit: false,
-   __experimental_actions: ['update', 'publish', /*'create', 'delete'*/],
+  __experimental_actions: ['update', 'publish', /*'create', 'delete'*/],
   icon: MdBusiness,
   fields: [
     {

--- a/studio/schemas/page.js
+++ b/studio/schemas/page.js
@@ -3,6 +3,7 @@ export default {
   title: 'Page',
   type: 'document',
   liveEdit: false,
+  __experimental_actions: ['update', 'publish', /*'create', 'delete'*/],
   fields: [
     {
       name: 'title',

--- a/studio/schemas/siteSettings.js
+++ b/studio/schemas/siteSettings.js
@@ -5,6 +5,7 @@ export default {
   title: 'Site Settings',
   type: 'document',
   liveEdit: false,
+  __experimental_actions: ['update', 'publish', /*'create', 'delete'*/],
   icon: MdSettings,
   fields: [
     {


### PR DESCRIPTION
This PR adds the experimental actions to the singleton documents so that they don't appear in the “Create new” menus (and can't be deleted).