### PR TITLE
Remove _id from GraphQL query

### DIFF
--- a/web/src/pages/about.js
+++ b/web/src/pages/about.js
@@ -14,7 +14,6 @@ export const query = graphql`
   query AboutPageQuery {
     page: sanityPage(_id: { regex: "/(drafts.|)about/" }) {
       id
-      _id
       title
       _rawBody
     }


### PR DESCRIPTION
fix: the about page was crashing - removed _id from about page query to make it work again.