### PR TITLE
adjust publish path in netlify.toml file

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
   base = "web/"
   command = "npm run build"
-  publish = "web/public"
+  publish = "public"


### PR DESCRIPTION
When attempting to deploy using Netlify.com using the initial settings in netlify.toml file I was experiencing the the following error:

Found Netlify configuration file netlify.toml in site root
Found Netlify configuration file(s). Overriding site configuration
Different base path detected, going to use the one specified in the Netlify configuration file: 'web/' versus '' in the Netlify UI
...
...
failed during stage 'building site': Deploy directory 'web/web/public' does not exist


Since the "base" path is already set to "web/" all I had to change was the "publish" path to be "public".

Once I made this change my deployments when through smoothly using Netlify.com
