### PR TITLE
Fixed React bug

### DIFF
--- a/web/src/components/block-content/slideshow.js
+++ b/web/src/components/block-content/slideshow.js
@@ -5,9 +5,9 @@ import { imageUrlFor } from '../../lib/image-url'
 import styles from './slideshow.module.css'
 
 function Slideshow (props) {
+  const [index, setIndex] = useState(0)
   if (!props.slides) return null
   const len = props.slides.length
-  const [index, setIndex] = useState(0)
   function handlePrev () {
     setIndex(Math.max(index - 1, 0))
   }


### PR DESCRIPTION
In some Node Versions, `npm start` will fail because the React Hook `useState` must be run before any return.
Struggled with this for a while :P